### PR TITLE
ci: updated branch reference main to master

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -7,7 +7,7 @@ env:
 on:
   pull_request:
     branches:
-      - main
+      - master
   workflow_dispatch:
 
 concurrency: 

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -6,8 +6,8 @@ env:
 
 on:
   pull_request:
-    branches:
-      - master
+    branches: [ master ]
+    types: [opened, synchronize]
   workflow_dispatch:
 
 concurrency: 

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -6,7 +6,7 @@ env:
 on:
   push:
     branches:
-      - main
+      - master
   workflow_dispatch:
 
 concurrency: 


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Update branch reference from 'main' to 'master' in GitHub Actions workflows for deploy-preview and deploy-production.